### PR TITLE
Fix kafka producer error handling

### DIFF
--- a/scala-generator/src/main/scala/models/KafkaProducer.scala
+++ b/scala-generator/src/main/scala/models/KafkaProducer.scala
@@ -93,7 +93,7 @@ package ${ssd.namespaces.base}.kafka {
                       }: _*)
         batch
       } recoverWith {
-        case ex ⇒ scala.util.Failure(new KafkaProducerException(s"Failed to publish $$topic message, to kafka queue.", ex))
+        case ex => scala.util.Failure(new KafkaProducerException(s"Failed to publish $$topic message, to kafka queue.", ex))
       }
     }
 
@@ -105,7 +105,7 @@ package ${ssd.namespaces.base}.kafka {
                       }: _*)
         batch
       } recoverWith {
-        case ex ⇒ scala.util.Failure(new KafkaProducerException(s"Failed to publish $$topic message, to kafka queue.", ex))
+        case ex => scala.util.Failure(new KafkaProducerException(s"Failed to publish $$topic message, to kafka queue.", ex))
       }
     }
 

--- a/scala-generator/src/main/scala/models/KafkaProducer.scala
+++ b/scala-generator/src/main/scala/models/KafkaProducer.scala
@@ -92,9 +92,8 @@ package ${ssd.namespaces.base}.kafka {
                         new KeyedMessage[String, String](topic, message.generateKey(tenant), Json.stringify(Json.toJson(message)))
                       }: _*)
         batch
-      } andThen {
-        case scala.util.Failure(ex) ⇒
-          throw new KafkaProducerException(s"Failed to publish $$topic message, to kafka queue.", ex)
+      } recoverWith {
+        case ex ⇒ scala.util.Failure(new KafkaProducerException(s"Failed to publish $$topic message, to kafka queue.", ex))
       }
     }
 
@@ -105,9 +104,8 @@ package ${ssd.namespaces.base}.kafka {
                         new KeyedMessage[String, String](topic, message.generateKey(tenant), Json.stringify(Json.toJson(message)))
                       }: _*)
         batch
-      } andThen {
-        case scala.util.Failure(ex) ⇒
-          throw new KafkaProducerException(s"Failed to publish $$topic message, to kafka queue.", ex)
+      } recoverWith {
+        case ex ⇒ scala.util.Failure(new KafkaProducerException(s"Failed to publish $$topic message, to kafka queue.", ex))
       }
     }
 


### PR DESCRIPTION
Errors thrown in `andThen` escape the `Try` and that's probably not what we want.

Use `recoverWith` instead so that it returns a `Failure` with a `KafkaProducerException`.
