### PR TITLE
Update consumer to ignore null messages

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,8 +5,3 @@ logs/
 *.downloaded.rb
 *.swp
 *.swo
-
-#eclipse
-.classpath
-.settings
-.project

--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,8 @@ logs/
 *.downloaded.rb
 *.swp
 *.swo
+
+#eclipse
+.classpath
+.settings
+.project

--- a/scala-generator/src/main/scala/models/KafkaConsumer.scala
+++ b/scala-generator/src/main/scala/models/KafkaConsumer.scala
@@ -148,12 +148,19 @@ package ${ssd.namespaces.base}.kafka {
             iterator.next()
           } match {
             case scala.util.Success(message) =>
-              val entity = Json.parse(message.message).as[${className}]
-              val topicRegex(tenant) = message.topic
-
-              val newSeq = messages.get(tenant).getOrElse(Seq.empty) :+ entity
-              val newMessages = messages + (tenant -> newSeq)
-
+              val payload = message.message
+              val newMessages = 
+                if (payload != null) {
+                  val entity = Json.parse(payload).as[${className}]
+                  val topicRegex(tenant) = message.topic
+  
+                  val newSeq = messages.get(tenant).getOrElse(Seq.empty) :+ entity
+                  
+                  messages + (tenant -> newSeq)
+                } else {
+                  messages
+                }
+              
               fetchBatch(remainingInBatch - 1, newMessages)
             case scala.util.Failure(ex) => ex match {
               case ex: ConsumerTimeoutException ⇒

--- a/scala-generator/src/main/scala/models/KafkaTests.scala
+++ b/scala-generator/src/main/scala/models/KafkaTests.scala
@@ -115,6 +115,37 @@ class ${className}Tests extends MovioSpec with KafkaTestKit {
         consumer.shutdown
       }
     }
+    
+    it("consumer ignores null payload messages, to support deletes on topics with compaction") {
+      new Fixture {
+        val topic = ${className}Topic.topic(tenant)
+        val rawProducer = createKeyedProducer[String, String](topic, kafkaServer)(k ⇒ k, m ⇒ m)
+
+        producer.sendWrapped(entity1, tenant)
+        // Produce null payload message
+        rawProducer.send("anId", null)
+        producer.sendWrapped(entity2, tenant)
+
+        // And consume them
+        var consumedEntities = Seq.empty[KafkaPerson]
+        awaitCondition("All messages should get processed") {
+          def processor(messages: Map[String, Seq[${className}]]): scala.util.Try[Map[String, Seq[${className}]]] =  {
+            println(messages)
+            println("do some side effecting stuff here")
+            scala.util.Success(messages)
+          }
+          
+          // Use distinct because there are items in the queue from other tests
+          consumer.processBatchThenCommit(processor, 100).get.get(tenant).foreach { messages =>
+            consumedEntities ++= messages
+          }
+          
+          consumedEntities shouldBe Seq(entity1, entity2)
+        }
+
+        consumer.shutdown
+      }
+    }
   }
 
   trait Fixture {


### PR DESCRIPTION
When you have compacted topics you can delete messages from the topic by sending a message with a matching key but no payload. The generated clients should be able to handle these messages.

This change makes the consumer effectively ignore these messages.
NB: We can't really do anything useful as the type is just a Seq[T] rather than a collection of key+payload pairs.
