### PR TITLE
Fix type error in kafka tests

### DIFF
--- a/scala-generator/src/main/scala/models/KafkaTests.scala
+++ b/scala-generator/src/main/scala/models/KafkaTests.scala
@@ -115,7 +115,7 @@ class ${className}Tests extends MovioSpec with KafkaTestKit {
         consumer.shutdown
       }
     }
-    
+
     it("consumer ignores null payload messages, to support deletes on topics with compaction") {
       new Fixture {
         val topic = ${className}Topic.topic(tenant)
@@ -127,19 +127,19 @@ class ${className}Tests extends MovioSpec with KafkaTestKit {
         producer.sendWrapped(entity2, tenant)
 
         // And consume them
-        var consumedEntities = Seq.empty[KafkaPerson]
+        var consumedEntities = Seq.empty[${className}]
         awaitCondition("All messages should get processed") {
           def processor(messages: Map[String, Seq[${className}]]): scala.util.Try[Map[String, Seq[${className}]]] =  {
             println(messages)
             println("do some side effecting stuff here")
             scala.util.Success(messages)
           }
-          
+
           // Use distinct because there are items in the queue from other tests
           consumer.processBatchThenCommit(processor, 100).get.get(tenant).foreach { messages =>
             consumedEntities ++= messages
           }
-          
+
           consumedEntities shouldBe Seq(entity1, entity2)
         }
 


### PR DESCRIPTION
Replace `KafkaPerson` with ${className} to fix a type error.
