### PR TITLE
ATM-10554: Support non-200 sucess status codes

### DIFF
--- a/lib/src/test/resources/generators/play-2-controller-members.txt
+++ b/lib/src/test/resources/generators/play-2-controller-members.txt
@@ -28,7 +28,7 @@ class MembersController @Singleton @Inject() (service: MembersService) extends p
   ) = play.api.mvc.Action.async {  request =>
     service.post(request, guid, organization, user, role).map{_ match {
       case scala.util.Success(result) =>
-        Ok(Json.toJson(result))
+        Status(201)(Json.toJson(result))
       case scala.util.Failure(ex) =>
         errorResponse(ex, msg => Error("500", msg))
     }}
@@ -42,7 +42,7 @@ class MembersController @Singleton @Inject() (service: MembersService) extends p
   ) = play.api.mvc.Action.async {  request =>
     service.get(request, guid, organizationGuid, userGuid, role).map{_ match {
       case scala.util.Success(result) =>
-        Ok(Json.toJson(result))
+        Status(200)(Json.toJson(result))
       case scala.util.Failure(ex) =>
         errorResponse(ex, msg => Error("500", msg))
     }}
@@ -53,7 +53,7 @@ class MembersController @Singleton @Inject() (service: MembersService) extends p
   ) = play.api.mvc.Action.async {  request =>
     service.get(request, organization).map{_ match {
       case scala.util.Success(result) =>
-        Ok(Json.toJson(result))
+        Status(200)(Json.toJson(result))
       case scala.util.Failure(ex) =>
         errorResponse(ex, msg => Error("500", msg))
     }}
@@ -68,7 +68,7 @@ class MembersController @Singleton @Inject() (service: MembersService) extends p
       case body: JsSuccess[Seq[com.bryzek.apidoc.reference.api.v0.models.Member]] =>
         service.post(request, body.get, organization).map{_ match {
           case scala.util.Success(result) =>
-            Ok(Json.toJson(result.size))
+            Status(200)(Json.toJson(result.size))
           case scala.util.Failure(ex) =>
             errorResponse(ex, msg => Error("500", msg))
         }}
@@ -84,7 +84,7 @@ class MembersController @Singleton @Inject() (service: MembersService) extends p
       case body: JsSuccess[Map[String, com.bryzek.apidoc.reference.api.v0.models.Member]] =>
         service.post(request, body.get, organization).map{_ match {
           case scala.util.Success(result) =>
-            Ok(Json.toJson(result.size))
+            Status(200)(Json.toJson(result.size))
           case scala.util.Failure(ex) =>
             errorResponse(ex, msg => Error("500", msg))
         }}

--- a/lib/src/test/resources/generators/play-2-standalone-json-spec-quality.txt
+++ b/lib/src/test/resources/generators/play-2-standalone-json-spec-quality.txt
@@ -491,16 +491,17 @@ package com.gilt.quality.v0.models {
     import play.api.libs.functional.syntax._
     import org.joda.time.format.DateTimeFormat
     import org.joda.time.format.DateTimeFormatterBuilder
+    import org.joda.time.format.ISODateTimeFormat
     import com.gilt.quality.v0.models.json._
 
     private[v0] val DateTimeFormatter =
       new DateTimeFormatterBuilder().append(
-        org.joda.time.format.ISODateTimeFormat.dateTime.getPrinter,
+        ISODateTimeFormat.dateTime.getPrinter,
         Array(
           DateTimeFormat.forPattern("yyyy-MM-dd'T'HH:mm:ssZZ").getParser,
           DateTimeFormat.forPattern("yyyy-MM-dd'T'HH:mm:ss.SSSZZ").getParser
         )
-      ).toFormatter
+      ).toFormatter.withOffsetParsed
 
     private[v0] implicit val jsonReadsUUID = __.read[String].map(java.util.UUID.fromString)
 

--- a/lib/src/test/resources/generators/play-2-standalone-json-spec-quality.txt
+++ b/lib/src/test/resources/generators/play-2-standalone-json-spec-quality.txt
@@ -489,7 +489,18 @@ package com.gilt.quality.v0.models {
     import play.api.libs.json.JsString
     import play.api.libs.json.Writes
     import play.api.libs.functional.syntax._
+    import org.joda.time.format.DateTimeFormat
+    import org.joda.time.format.DateTimeFormatterBuilder
     import com.gilt.quality.v0.models.json._
+
+    private[v0] val DateTimeFormatter =
+      new DateTimeFormatterBuilder().append(
+        org.joda.time.format.ISODateTimeFormat.dateTime.getPrinter,
+        Array(
+          DateTimeFormat.forPattern("yyyy-MM-dd'T'HH:mm:ssZZ").getParser,
+          DateTimeFormat.forPattern("yyyy-MM-dd'T'HH:mm:ss.SSSZZ").getParser
+        )
+      ).toFormatter
 
     private[v0] implicit val jsonReadsUUID = __.read[String].map(java.util.UUID.fromString)
 
@@ -498,14 +509,12 @@ package com.gilt.quality.v0.models {
     }
 
     private[v0] implicit val jsonReadsJodaDateTime = __.read[String].map { str =>
-      import org.joda.time.format.ISODateTimeFormat.dateTimeParser
-      dateTimeParser.parseDateTime(str)
+      DateTimeFormatter.parseDateTime(str)
     }
 
     private[v0] implicit val jsonWritesJodaDateTime = new Writes[org.joda.time.DateTime] {
       def writes(x: org.joda.time.DateTime) = {
-        import org.joda.time.format.ISODateTimeFormat.dateTime
-        val str = dateTime.print(x)
+        val str = DateTimeFormatter.print(x)
         JsString(str)
       }
     }

--- a/lib/src/test/resources/union-types-discriminator-service-play-24.txt
+++ b/lib/src/test/resources/union-types-discriminator-service-play-24.txt
@@ -78,16 +78,17 @@ package com.bryzek.apidoc.example.union.types.discriminator.v0.models {
     import play.api.libs.functional.syntax._
     import org.joda.time.format.DateTimeFormat
     import org.joda.time.format.DateTimeFormatterBuilder
+    import org.joda.time.format.ISODateTimeFormat
     import com.bryzek.apidoc.example.union.types.discriminator.v0.models.json._
 
     private[v0] val DateTimeFormatter =
       new DateTimeFormatterBuilder().append(
-        org.joda.time.format.ISODateTimeFormat.dateTime.getPrinter,
+        ISODateTimeFormat.dateTime.getPrinter,
         Array(
           DateTimeFormat.forPattern("yyyy-MM-dd'T'HH:mm:ssZZ").getParser,
           DateTimeFormat.forPattern("yyyy-MM-dd'T'HH:mm:ss.SSSZZ").getParser
         )
-      ).toFormatter
+      ).toFormatter.withOffsetParsed
 
     private[v0] implicit val jsonReadsUUID = __.read[String].map(java.util.UUID.fromString)
 

--- a/lib/src/test/resources/union-types-discriminator-service-play-24.txt
+++ b/lib/src/test/resources/union-types-discriminator-service-play-24.txt
@@ -76,7 +76,18 @@ package com.bryzek.apidoc.example.union.types.discriminator.v0.models {
     import play.api.libs.json.JsString
     import play.api.libs.json.Writes
     import play.api.libs.functional.syntax._
+    import org.joda.time.format.DateTimeFormat
+    import org.joda.time.format.DateTimeFormatterBuilder
     import com.bryzek.apidoc.example.union.types.discriminator.v0.models.json._
+
+    private[v0] val DateTimeFormatter =
+      new DateTimeFormatterBuilder().append(
+        org.joda.time.format.ISODateTimeFormat.dateTime.getPrinter,
+        Array(
+          DateTimeFormat.forPattern("yyyy-MM-dd'T'HH:mm:ssZZ").getParser,
+          DateTimeFormat.forPattern("yyyy-MM-dd'T'HH:mm:ss.SSSZZ").getParser
+        )
+      ).toFormatter
 
     private[v0] implicit val jsonReadsUUID = __.read[String].map(java.util.UUID.fromString)
 
@@ -85,14 +96,12 @@ package com.bryzek.apidoc.example.union.types.discriminator.v0.models {
     }
 
     private[v0] implicit val jsonReadsJodaDateTime = __.read[String].map { str =>
-      import org.joda.time.format.ISODateTimeFormat.dateTimeParser
-      dateTimeParser.parseDateTime(str)
+      DateTimeFormatter.parseDateTime(str)
     }
 
     private[v0] implicit val jsonWritesJodaDateTime = new Writes[org.joda.time.DateTime] {
       def writes(x: org.joda.time.DateTime) = {
-        import org.joda.time.format.ISODateTimeFormat.dateTime
-        val str = dateTime.print(x)
+        val str = DateTimeFormatter.print(x)
         JsString(str)
       }
     }

--- a/scala-generator/src/main/scala/models/Play2JsonStandalone.scala
+++ b/scala-generator/src/main/scala/models/Play2JsonStandalone.scala
@@ -43,7 +43,18 @@ package ${ssd.namespaces.models} {
     import play.api.libs.json.JsString
     import play.api.libs.json.Writes
     import play.api.libs.functional.syntax._
+    import org.joda.time.format.DateTimeFormat
+    import org.joda.time.format.DateTimeFormatterBuilder
 ${JsonImports(form.service).mkString("\n").indent(4)}
+
+    private[${ssd.namespaces.last}] val DateTimeFormatter =
+      new DateTimeFormatterBuilder().append(
+        org.joda.time.format.ISODateTimeFormat.dateTime.getPrinter,
+        Array(
+          DateTimeFormat.forPattern("yyyy-MM-dd'T'HH:mm:ssZZ").getParser,
+          DateTimeFormat.forPattern("yyyy-MM-dd'T'HH:mm:ss.SSSZZ").getParser
+        )
+      ).toFormatter
 
     private[${ssd.namespaces.last}] implicit val jsonReadsUUID = __.read[String].map(java.util.UUID.fromString)
 
@@ -52,14 +63,12 @@ ${JsonImports(form.service).mkString("\n").indent(4)}
     }
 
     private[${ssd.namespaces.last}] implicit val jsonReadsJodaDateTime = __.read[String].map { str =>
-      import org.joda.time.format.ISODateTimeFormat.dateTimeParser
-      dateTimeParser.parseDateTime(str)
+      DateTimeFormatter.parseDateTime(str)
     }
 
     private[${ssd.namespaces.last}] implicit val jsonWritesJodaDateTime = new Writes[org.joda.time.DateTime] {
       def writes(x: org.joda.time.DateTime) = {
-        import org.joda.time.format.ISODateTimeFormat.dateTime
-        val str = dateTime.print(x)
+        val str = DateTimeFormatter.print(x)
         JsString(str)
       }
     }

--- a/scala-generator/src/main/scala/models/Play2JsonStandalone.scala
+++ b/scala-generator/src/main/scala/models/Play2JsonStandalone.scala
@@ -45,16 +45,17 @@ package ${ssd.namespaces.models} {
     import play.api.libs.functional.syntax._
     import org.joda.time.format.DateTimeFormat
     import org.joda.time.format.DateTimeFormatterBuilder
+    import org.joda.time.format.ISODateTimeFormat
 ${JsonImports(form.service).mkString("\n").indent(4)}
 
     private[${ssd.namespaces.last}] val DateTimeFormatter =
       new DateTimeFormatterBuilder().append(
-        org.joda.time.format.ISODateTimeFormat.dateTime.getPrinter,
+        ISODateTimeFormat.dateTime.getPrinter,
         Array(
           DateTimeFormat.forPattern("yyyy-MM-dd'T'HH:mm:ssZZ").getParser,
           DateTimeFormat.forPattern("yyyy-MM-dd'T'HH:mm:ss.SSSZZ").getParser
         )
-      ).toFormatter
+      ).toFormatter.withOffsetParsed
 
     private[${ssd.namespaces.last}] implicit val jsonReadsUUID = __.read[String].map(java.util.UUID.fromString)
 

--- a/scala-generator/src/main/scala/models/Play2Models.scala
+++ b/scala-generator/src/main/scala/models/Play2Models.scala
@@ -55,7 +55,18 @@ package ${ssd.namespaces.models} {
     import play.api.libs.json.JsString
     import play.api.libs.json.Writes
     import play.api.libs.functional.syntax._
+    import org.joda.time.format.DateTimeFormat
+    import org.joda.time.format.DateTimeFormatterBuilder
 ${JsonImports(form.service).mkString("\n").indent(4)}
+
+    private[${ssd.namespaces.last}] val DateTimeFormatter =
+      new DateTimeFormatterBuilder().append(
+        org.joda.time.format.ISODateTimeFormat.dateTime.getPrinter,
+        Array(
+          DateTimeFormat.forPattern("yyyy-MM-dd'T'HH:mm:ssZZ").getParser,
+          DateTimeFormat.forPattern("yyyy-MM-dd'T'HH:mm:ss.SSSZZ").getParser
+        )
+      ).toFormatter
 
     private[${ssd.namespaces.last}] implicit val jsonReadsUUID = __.read[String].map(java.util.UUID.fromString)
 
@@ -64,14 +75,12 @@ ${JsonImports(form.service).mkString("\n").indent(4)}
     }
 
     private[${ssd.namespaces.last}] implicit val jsonReadsJodaDateTime = __.read[String].map { str =>
-      import org.joda.time.format.ISODateTimeFormat.dateTimeParser
-      dateTimeParser.parseDateTime(str)
+      DateTimeFormatter.parseDateTime(str)
     }
 
     private[${ssd.namespaces.last}] implicit val jsonWritesJodaDateTime = new Writes[org.joda.time.DateTime] {
       def writes(x: org.joda.time.DateTime) = {
-        import org.joda.time.format.ISODateTimeFormat.dateTime
-        val str = dateTime.print(x)
+        val str = DateTimeFormatter.print(x)
         JsString(str)
       }
     }

--- a/scala-generator/src/main/scala/models/Play2Models.scala
+++ b/scala-generator/src/main/scala/models/Play2Models.scala
@@ -57,16 +57,17 @@ package ${ssd.namespaces.models} {
     import play.api.libs.functional.syntax._
     import org.joda.time.format.DateTimeFormat
     import org.joda.time.format.DateTimeFormatterBuilder
+    import org.joda.time.format.ISODateTimeFormat
 ${JsonImports(form.service).mkString("\n").indent(4)}
 
     private[${ssd.namespaces.last}] val DateTimeFormatter =
       new DateTimeFormatterBuilder().append(
-        org.joda.time.format.ISODateTimeFormat.dateTime.getPrinter,
+        ISODateTimeFormat.dateTime.getPrinter,
         Array(
           DateTimeFormat.forPattern("yyyy-MM-dd'T'HH:mm:ssZZ").getParser,
           DateTimeFormat.forPattern("yyyy-MM-dd'T'HH:mm:ss.SSSZZ").getParser
         )
-      ).toFormatter
+      ).toFormatter.withOffsetParsed
 
     private[${ssd.namespaces.last}] implicit val jsonReadsUUID = __.read[String].map(java.util.UUID.fromString)
 

--- a/scala-generator/src/main/scala/models/PlayController.scala
+++ b/scala-generator/src/main/scala/models/PlayController.scala
@@ -1,7 +1,7 @@
 package scala.models
 
 import com.bryzek.apidoc.generator.v0.models.{File, InvocationForm}
-import com.bryzek.apidoc.spec.v0.models.Attribute
+import com.bryzek.apidoc.spec.v0.models.{Attribute, ResponseCodeInt}
 import lib.Text._
 import lib.generator.CodeGenerator
 import scala.generator.{ScalaEnums, ScalaCaseClasses, ScalaService, ScalaResource, ScalaOperation, ScalaUtil}
@@ -56,13 +56,20 @@ trait PlayController extends CodeGenerator {
                                                           case _ => ""
                                                         }).getOrElse("")
 
+        // Use the first successful status code in the defined responses, otherwise default to 200
+        val successStatusCode = operation.responses
+          .filter(_.isSuccess)
+          .map(_.code)
+          .collectFirst { case r @ ResponseCodeInt(code) ⇒ code }
+          .getOrElse(200)
+
         // Use in service
         val resultType = operation.resultType
 
         val block = s"""
 service.${method}(${argNameList}).map{_ match {
   case scala.util.Success(result) =>
-    Ok(Json.toJson(result${returnSizeIfCollection}))
+    Status($successStatusCode)(Json.toJson(result${returnSizeIfCollection}))
   case scala.util.Failure(ex) =>
     errorResponse(ex, msg => Error("500", msg))
 }}"""
@@ -80,7 +87,7 @@ def ${operation.name}(${argList}) = play.api.mvc.Action.async(play.api.mvc.BodyP
 def ${operation.name}(${argList}) = play.api.mvc.Action.async {  request =>${block.indent(2)}
 }"""
         }
-      }.mkString("\n") 
+      }.mkString("\n")
 
 
       val source = s"""$header

--- a/scala-generator/src/main/scala/models/PlayController.scala
+++ b/scala-generator/src/main/scala/models/PlayController.scala
@@ -60,7 +60,7 @@ trait PlayController extends CodeGenerator {
         val successStatusCode = operation.responses
           .filter(_.isSuccess)
           .map(_.code)
-          .collectFirst { case r @ ResponseCodeInt(code) ⇒ code }
+          .collectFirst { case ResponseCodeInt(code) ⇒ code }
           .getOrElse(200)
 
         // Use in service


### PR DESCRIPTION
Instead of using hard-coded `Ok`, the generated play 2 controller
now returns the first success status code defined in the responses
of an operation. E.g.

The following responses:

``` json
  "responses": [
    {
      "code": { "integer": { "value": 201 } },
      "attributes": [],
      "type": "member"
    },
    {
      "code": { "integer": { "value": 409 } },
      "attributes": [],
      "type": "[error]"
    }
  ]
```

generates:

``` scala
  service.post(request, guid, organization, user, role).map{_ match {
    case scala.util.Success(result) =>
      Status(201)(Json.toJson(result))
    case scala.util.Failure(ex) =>
      errorResponse(ex, msg => Error("500", msg))
  }}
```
