### PR TITLE
Add optional `tenants` parameter to generated consumer

### DIFF
--- a/lib/src/test/resources/kafka-consumer.txt
+++ b/lib/src/test/resources/kafka-consumer.txt
@@ -74,14 +74,15 @@ package test.apidoc.apidoctest.v0.kafka {
    */
   class KafkaMemberConsumer (
     config: Config,
-    consumerGroupId: String
+    consumerGroupId: String,
+    tenants: Option[Seq[String]] = None
   ) extends KafkaConsumer[KafkaMember] {
     import KafkaMemberConsumer._
 
     lazy val topicRegex: Regex =
       KafkaMemberTopic.topicRegex(
         config.getString(TopicInstanceKey),
-        config.getStringList(TenantsKey)
+        tenants.getOrElse(config.getStringList(TenantsKey))
       ).r
 
     lazy val topicFilter = new Whitelist(topicRegex.toString)

--- a/scala-generator/src/main/scala/models/KafkaConsumer.scala
+++ b/scala-generator/src/main/scala/models/KafkaConsumer.scala
@@ -123,14 +123,15 @@ package ${ssd.namespaces.base}.kafka {
    */
   class ${className}Consumer (
     config: Config,
-    consumerGroupId: String
+    consumerGroupId: String,
+    tenants: Option[Seq[String]] = None
   ) extends KafkaConsumer[${className}] {
     import ${className}Consumer._
 
     lazy val topicRegex: Regex =
       ${className}Topic.topicRegex(
         config.getString(TopicInstanceKey),
-        config.getStringList(TenantsKey)
+        tenants.getOrElse(config.getStringList(TenantsKey))
       ).r
 
     lazy val topicFilter = new Whitelist(topicRegex.toString)


### PR DESCRIPTION
If it's present, it overrides the tenants in the configuration.
