### PR TITLE
Add empty arglist to generated close methods

### DIFF
--- a/lib/src/test/resources/example-union-types-play-24.txt
+++ b/lib/src/test/resources/example-union-types-play-24.txt
@@ -175,7 +175,7 @@ package com.bryzek.apidoc.example.union.types.v0 {
       result
     }
 
-    def close: Unit = {
+    def close(): Unit = {
       client match {
         case Some(c) => 
           if (! autoClose)

--- a/lib/src/test/resources/generators/collection-json-defaults-play-24.txt
+++ b/lib/src/test/resources/generators/collection-json-defaults-play-24.txt
@@ -179,7 +179,7 @@ package com.gilt.test.v0 {
       result
     }
 
-    def close: Unit = {
+    def close(): Unit = {
       client match {
         case Some(c) => 
           if (! autoClose)

--- a/lib/src/test/resources/generators/reference-spec-play-24.txt
+++ b/lib/src/test/resources/generators/reference-spec-play-24.txt
@@ -368,7 +368,7 @@ package com.bryzek.apidoc.reference.api.v0 {
       result
     }
 
-    def close: Unit = {
+    def close(): Unit = {
       client match {
         case Some(c) => 
           if (! autoClose)

--- a/lib/src/test/resources/generators/reference-spec-play-24.txt~HEAD
+++ b/lib/src/test/resources/generators/reference-spec-play-24.txt~HEAD
@@ -368,7 +368,7 @@ package com.bryzek.apidoc.reference.api.v0 {
       result
     }
 
-    def close: Unit = {
+    def close(): Unit = {
       client match {
         case Some(c) => 
           if (! autoClose)

--- a/lib/src/test/resources/generators/reference-with-imports-spec-play-24.txt
+++ b/lib/src/test/resources/generators/reference-with-imports-spec-play-24.txt
@@ -356,7 +356,7 @@ package com.bryzek.apidoc.reference.api.v0 {
       result
     }
 
-    def close: Unit = {
+    def close(): Unit = {
       client match {
         case Some(c) => 
           if (! autoClose)

--- a/scala-generator/src/main/scala/models/Play2ClientGenerator.scala
+++ b/scala-generator/src/main/scala/models/Play2ClientGenerator.scala
@@ -194,7 +194,7 @@ ${methodGenerator.objects().indent(4)}
       result
     }
 
-    def close: Unit = {
+    def close(): Unit = {
       client match {
         case Some(c) => 
           if (! autoClose)


### PR DESCRIPTION
Prevents scala compiler warnings about side-effecting nullary methods.

Before:

``` scala
def close: Unit = { ... }
```

After

``` scala
def close(): Unit = { ... }
```
