### PR TITLE
MM-1603: header parameters on client methods

### DIFF
--- a/lib/src/test/resources/example-union-types-play-24.txt
+++ b/lib/src/test/resources/example-union-types-play-24.txt
@@ -131,38 +131,39 @@ package com.bryzek.apidoc.example.union.types.v0 {
       method: String,
       path: String,
       queryParameters: Seq[(String, String)] = Seq.empty,
+      headers: Seq[(String, String)] = Seq.empty,
       body: Option[play.api.libs.json.JsValue] = None
     )(implicit ec: scala.concurrent.ExecutionContext): scala.concurrent.Future[play.api.libs.ws.WSResponse] = {
       val result = method.toUpperCase match {
         case "GET" => {
-          _logRequest("GET", _requestHolder(path).withQueryString(queryParameters:_*)).get()
+          _logRequest("GET", _requestHolder(path).withQueryString(queryParameters:_*).withHeaders(headers:_*)).get()
         }
         case "POST" => {
-          _logRequest("POST", _requestHolder(path).withQueryString(queryParameters:_*).withHeaders("Content-Type" -> "application/json; charset=UTF-8")).post(body.getOrElse(play.api.libs.json.Json.obj()))
+          _logRequest("POST", _requestHolder(path).withQueryString(queryParameters:_*).withHeaders("Content-Type" -> "application/json; charset=UTF-8", headers:_*)).post(body.getOrElse(play.api.libs.json.Json.obj()))
         }
         case "PUT" => {
-          _logRequest("PUT", _requestHolder(path).withQueryString(queryParameters:_*).withHeaders("Content-Type" -> "application/json; charset=UTF-8")).put(body.getOrElse(play.api.libs.json.Json.obj()))
+          _logRequest("PUT", _requestHolder(path).withQueryString(queryParameters:_*).withHeaders("Content-Type" -> "application/json; charset=UTF-8", headers:_*)).put(body.getOrElse(play.api.libs.json.Json.obj()))
         }
         case "PATCH" => {
-          _logRequest("PATCH", _requestHolder(path).withQueryString(queryParameters:_*)).patch(body.getOrElse(play.api.libs.json.Json.obj()))
+          _logRequest("PATCH", _requestHolder(path).withQueryString(queryParameters:_*).withHeaders(headers:_*)).patch(body.getOrElse(play.api.libs.json.Json.obj()))
         }
         case "DELETE" => {
-          _logRequest("DELETE", _requestHolder(path).withQueryString(queryParameters:_*)).delete()
+          _logRequest("DELETE", _requestHolder(path).withQueryString(queryParameters:_*).withHeaders(headers:_*)).delete()
         }
          case "HEAD" => {
-          _logRequest("HEAD", _requestHolder(path).withQueryString(queryParameters:_*)).head()
+          _logRequest("HEAD", _requestHolder(path).withQueryString(queryParameters:_*).withHeaders(headers:_*)).head()
         }
          case "OPTIONS" => {
-          _logRequest("OPTIONS", _requestHolder(path).withQueryString(queryParameters:_*)).options()
+          _logRequest("OPTIONS", _requestHolder(path).withQueryString(queryParameters:_*).withHeaders(headers:_*)).options()
         }
         case _ => {
-          _logRequest(method, _requestHolder(path).withQueryString(queryParameters:_*))
+          _logRequest(method, _requestHolder(path).withQueryString(queryParameters:_*).withHeaders(headers:_*))
           sys.error("Unsupported method[%s]".format(method))
         }
       }
       // Close connection if needed
       result.onComplete {
-        case _ => // 
+        case _ => //
           client match {
             case Some(c) =>
               if (autoClose) {
@@ -177,7 +178,7 @@ package com.bryzek.apidoc.example.union.types.v0 {
 
     def close: Unit = {
       client match {
-        case Some(c) => 
+        case Some(c) =>
           if (! autoClose)
             c.close
           else

--- a/lib/src/test/resources/example-union-types-play-24.txt
+++ b/lib/src/test/resources/example-union-types-play-24.txt
@@ -136,28 +136,39 @@ package com.bryzek.apidoc.example.union.types.v0 {
     )(implicit ec: scala.concurrent.ExecutionContext): scala.concurrent.Future[play.api.libs.ws.WSResponse] = {
       val result = method.toUpperCase match {
         case "GET" => {
-          _logRequest("GET", _requestHolder(path).withQueryString(queryParameters:_*).withHeaders(headers:_*)).get()
+          val request = _requestHolder(path).withQueryString(queryParameters:_*).withHeaders(headers:_*)
+          _logRequest("GET", request).get()
         }
         case "POST" => {
-          _logRequest("POST", _requestHolder(path).withQueryString(queryParameters:_*).withHeaders("Content-Type" -> "application/json; charset=UTF-8", headers:_*)).post(body.getOrElse(play.api.libs.json.Json.obj()))
+          val allHeaders = ("Content-Type" -> "application/json; charset=UTF-8") +: headers
+          val request = _requestHolder(path).withQueryString(queryParameters:_*).withHeaders(allHeaders:_*)
+          _logRequest("POST", request).post(body.getOrElse(play.api.libs.json.Json.obj()))
         }
         case "PUT" => {
-          _logRequest("PUT", _requestHolder(path).withQueryString(queryParameters:_*).withHeaders("Content-Type" -> "application/json; charset=UTF-8", headers:_*)).put(body.getOrElse(play.api.libs.json.Json.obj()))
+          val allHeaders = ("Content-Type" -> "application/json; charset=UTF-8") +: headers
+          val request = _requestHolder(path).withQueryString(queryParameters:_*).withHeaders(allHeaders:_*)
+          val payload = body.getOrElse(play.api.libs.json.Json.obj())
+          _logRequest("PUT", request).put(payload)
         }
         case "PATCH" => {
-          _logRequest("PATCH", _requestHolder(path).withQueryString(queryParameters:_*).withHeaders(headers:_*)).patch(body.getOrElse(play.api.libs.json.Json.obj()))
+          val request = _requestHolder(path).withQueryString(queryParameters:_*).withHeaders(headers:_*)
+          val payload = body.getOrElse(play.api.libs.json.Json.obj())
+          _logRequest("PATCH", request).patch(payload)
         }
         case "DELETE" => {
-          _logRequest("DELETE", _requestHolder(path).withQueryString(queryParameters:_*).withHeaders(headers:_*)).delete()
+          val request = _requestHolder(path).withQueryString(queryParameters:_*).withHeaders(headers:_*)
+          _logRequest("DELETE", request).delete()
         }
          case "HEAD" => {
-          _logRequest("HEAD", _requestHolder(path).withQueryString(queryParameters:_*).withHeaders(headers:_*)).head()
+           val request = _requestHolder(path).withQueryString(queryParameters:_*).withHeaders(headers:_*)
+          _logRequest("HEAD", request).head()
         }
          case "OPTIONS" => {
           _logRequest("OPTIONS", _requestHolder(path).withQueryString(queryParameters:_*).withHeaders(headers:_*)).options()
         }
         case _ => {
-          _logRequest(method, _requestHolder(path).withQueryString(queryParameters:_*).withHeaders(headers:_*))
+          val request = _requestHolder(path).withQueryString(queryParameters:_*).withHeaders(headers:_*)
+          _logRequest(method, request)
           sys.error("Unsupported method[%s]".format(method))
         }
       }

--- a/lib/src/test/resources/examples/play2-client-generator-spec-has-headers.json
+++ b/lib/src/test/resources/examples/play2-client-generator-spec-has-headers.json
@@ -1,0 +1,87 @@
+{
+  "apidoc": {
+    "version": "0.9.6"
+  },
+  "name": "apidoc Example Spec with Headers",
+  "organization": {
+    "key": "gilt"
+  },
+  "application": {
+    "key": "apidoc-example-spec-with-headers"
+  },
+  "namespace": "spec",
+  "version": "0.0.1-dev",
+  "info": [],
+  "imports": [],
+  "attributes": [],
+  "enums": [],
+  "unions": [],
+
+  "headers": [
+    {
+      "name": "Authorization",
+      "type": "string",
+      "required": true,
+      "attributes": []
+    },
+    {
+      "name": "DogeCount",
+      "type": "integer",
+      "required": false,
+      "attributes": []
+    }
+  ],
+
+  "models": [
+    {
+      "name": "user",
+      "plural": "users",
+      "fields": [
+        {
+          "name": "email",
+          "type": "string",
+          "required": true,
+          "attributes": []
+        }
+      ],
+      "attributes": []
+    }
+  ],
+  "resources": [
+    {
+      "type": "user",
+      "plural": "users",
+      "operations": [
+        {
+          "method": "GET",
+          "path": "/users",
+          "parameters": [
+            {
+              "name": "id",
+              "type": "long",
+              "location": "Query",
+              "required": true,
+              "description": ""
+            },
+            {
+              "name": "age",
+              "type": "integer",
+              "location": "Query",
+              "required": false,
+              "description": ""
+            }
+          ],
+          "responses": [
+            {
+              "code": { "integer": { "value": 200 } },
+              "type": "[user]",
+              "attributes": []
+            }
+          ],
+          "attributes": []
+        }
+      ],
+      "attributes": []
+    }
+  ]
+}

--- a/lib/src/test/resources/generators/collection-json-defaults-play-24.txt
+++ b/lib/src/test/resources/generators/collection-json-defaults-play-24.txt
@@ -140,28 +140,39 @@ package com.gilt.test.v0 {
     )(implicit ec: scala.concurrent.ExecutionContext): scala.concurrent.Future[play.api.libs.ws.WSResponse] = {
       val result = method.toUpperCase match {
         case "GET" => {
-          _logRequest("GET", _requestHolder(path).withQueryString(queryParameters:_*).withHeaders(headers:_*)).get()
+          val request = _requestHolder(path).withQueryString(queryParameters:_*).withHeaders(headers:_*)
+          _logRequest("GET", request).get()
         }
         case "POST" => {
-          _logRequest("POST", _requestHolder(path).withQueryString(queryParameters:_*).withHeaders("Content-Type" -> "application/json; charset=UTF-8", headers:_*)).post(body.getOrElse(play.api.libs.json.Json.obj()))
+          val allHeaders = ("Content-Type" -> "application/json; charset=UTF-8") +: headers
+          val request = _requestHolder(path).withQueryString(queryParameters:_*).withHeaders(allHeaders:_*)
+          _logRequest("POST", request).post(body.getOrElse(play.api.libs.json.Json.obj()))
         }
         case "PUT" => {
-          _logRequest("PUT", _requestHolder(path).withQueryString(queryParameters:_*).withHeaders("Content-Type" -> "application/json; charset=UTF-8", headers:_*)).put(body.getOrElse(play.api.libs.json.Json.obj()))
+          val allHeaders = ("Content-Type" -> "application/json; charset=UTF-8") +: headers
+          val request = _requestHolder(path).withQueryString(queryParameters:_*).withHeaders(allHeaders:_*)
+          val payload = body.getOrElse(play.api.libs.json.Json.obj())
+          _logRequest("PUT", request).put(payload)
         }
         case "PATCH" => {
-          _logRequest("PATCH", _requestHolder(path).withQueryString(queryParameters:_*).withHeaders(headers:_*)).patch(body.getOrElse(play.api.libs.json.Json.obj()))
+          val request = _requestHolder(path).withQueryString(queryParameters:_*).withHeaders(headers:_*)
+          val payload = body.getOrElse(play.api.libs.json.Json.obj())
+          _logRequest("PATCH", request).patch(payload)
         }
         case "DELETE" => {
-          _logRequest("DELETE", _requestHolder(path).withQueryString(queryParameters:_*).withHeaders(headers:_*)).delete()
+          val request = _requestHolder(path).withQueryString(queryParameters:_*).withHeaders(headers:_*)
+          _logRequest("DELETE", request).delete()
         }
          case "HEAD" => {
-          _logRequest("HEAD", _requestHolder(path).withQueryString(queryParameters:_*).withHeaders(headers:_*)).head()
+           val request = _requestHolder(path).withQueryString(queryParameters:_*).withHeaders(headers:_*)
+          _logRequest("HEAD", request).head()
         }
          case "OPTIONS" => {
           _logRequest("OPTIONS", _requestHolder(path).withQueryString(queryParameters:_*).withHeaders(headers:_*)).options()
         }
         case _ => {
-          _logRequest(method, _requestHolder(path).withQueryString(queryParameters:_*).withHeaders(headers:_*))
+          val request = _requestHolder(path).withQueryString(queryParameters:_*).withHeaders(headers:_*)
+          _logRequest(method, request)
           sys.error("Unsupported method[%s]".format(method))
         }
       }

--- a/lib/src/test/resources/generators/collection-json-defaults-play-24.txt
+++ b/lib/src/test/resources/generators/collection-json-defaults-play-24.txt
@@ -135,38 +135,39 @@ package com.gilt.test.v0 {
       method: String,
       path: String,
       queryParameters: Seq[(String, String)] = Seq.empty,
+      headers: Seq[(String, String)] = Seq.empty,
       body: Option[play.api.libs.json.JsValue] = None
     )(implicit ec: scala.concurrent.ExecutionContext): scala.concurrent.Future[play.api.libs.ws.WSResponse] = {
       val result = method.toUpperCase match {
         case "GET" => {
-          _logRequest("GET", _requestHolder(path).withQueryString(queryParameters:_*)).get()
+          _logRequest("GET", _requestHolder(path).withQueryString(queryParameters:_*).withHeaders(headers:_*)).get()
         }
         case "POST" => {
-          _logRequest("POST", _requestHolder(path).withQueryString(queryParameters:_*).withHeaders("Content-Type" -> "application/json; charset=UTF-8")).post(body.getOrElse(play.api.libs.json.Json.obj()))
+          _logRequest("POST", _requestHolder(path).withQueryString(queryParameters:_*).withHeaders("Content-Type" -> "application/json; charset=UTF-8", headers:_*)).post(body.getOrElse(play.api.libs.json.Json.obj()))
         }
         case "PUT" => {
-          _logRequest("PUT", _requestHolder(path).withQueryString(queryParameters:_*).withHeaders("Content-Type" -> "application/json; charset=UTF-8")).put(body.getOrElse(play.api.libs.json.Json.obj()))
+          _logRequest("PUT", _requestHolder(path).withQueryString(queryParameters:_*).withHeaders("Content-Type" -> "application/json; charset=UTF-8", headers:_*)).put(body.getOrElse(play.api.libs.json.Json.obj()))
         }
         case "PATCH" => {
-          _logRequest("PATCH", _requestHolder(path).withQueryString(queryParameters:_*)).patch(body.getOrElse(play.api.libs.json.Json.obj()))
+          _logRequest("PATCH", _requestHolder(path).withQueryString(queryParameters:_*).withHeaders(headers:_*)).patch(body.getOrElse(play.api.libs.json.Json.obj()))
         }
         case "DELETE" => {
-          _logRequest("DELETE", _requestHolder(path).withQueryString(queryParameters:_*)).delete()
+          _logRequest("DELETE", _requestHolder(path).withQueryString(queryParameters:_*).withHeaders(headers:_*)).delete()
         }
          case "HEAD" => {
-          _logRequest("HEAD", _requestHolder(path).withQueryString(queryParameters:_*)).head()
+          _logRequest("HEAD", _requestHolder(path).withQueryString(queryParameters:_*).withHeaders(headers:_*)).head()
         }
          case "OPTIONS" => {
-          _logRequest("OPTIONS", _requestHolder(path).withQueryString(queryParameters:_*)).options()
+          _logRequest("OPTIONS", _requestHolder(path).withQueryString(queryParameters:_*).withHeaders(headers:_*)).options()
         }
         case _ => {
-          _logRequest(method, _requestHolder(path).withQueryString(queryParameters:_*))
+          _logRequest(method, _requestHolder(path).withQueryString(queryParameters:_*).withHeaders(headers:_*))
           sys.error("Unsupported method[%s]".format(method))
         }
       }
       // Close connection if needed
       result.onComplete {
-        case _ => // 
+        case _ => //
           client match {
             case Some(c) =>
               if (autoClose) {
@@ -181,7 +182,7 @@ package com.gilt.test.v0 {
 
     def close: Unit = {
       client match {
-        case Some(c) => 
+        case Some(c) =>
           if (! autoClose)
             c.close
           else

--- a/lib/src/test/resources/generators/play2-client-generator-spec-errors-package-no-models-with-headers.txt
+++ b/lib/src/test/resources/generators/play2-client-generator-spec-errors-package-no-models-with-headers.txt
@@ -1,0 +1,21 @@
+object Users extends Users {
+  override def get(
+    id: Long,
+    age: _root_.scala.Option[Int] = None
+  )(authorization: String, dogeCount: _root_.scala.Option[Int])(implicit ec: scala.concurrent.ExecutionContext): scala.concurrent.Future[Seq[spec.models.User]] = {
+    val queryParameters = Seq(
+      Some("id" -> id.toString),
+      age.map("age" -> _.toString)
+    ).flatten
+
+    val headers = Seq(
+      Some("Authorization" -> authorization),
+      dogeCount.map("DogeCount" -> _.toString)
+    ).flatten
+
+    _executeRequest("GET", s"/users", queryParameters = queryParameters, headers = headers).map {
+      case r if r.status == 200 => _root_.test.apidoc.Client.parseJson("Seq[spec.models.User]", r, _.validate[Seq[spec.models.User]])
+      case r => throw new test.apidoc.errors.FailedRequest(r.status, s"Unsupported response code[${r.status}]. Expected: 200")
+    }
+  }
+}

--- a/lib/src/test/resources/generators/reference-spec-play-24.txt
+++ b/lib/src/test/resources/generators/reference-spec-play-24.txt
@@ -324,38 +324,39 @@ package com.bryzek.apidoc.reference.api.v0 {
       method: String,
       path: String,
       queryParameters: Seq[(String, String)] = Seq.empty,
+      headers: Seq[(String, String)] = Seq.empty,
       body: Option[play.api.libs.json.JsValue] = None
     )(implicit ec: scala.concurrent.ExecutionContext): scala.concurrent.Future[play.api.libs.ws.WSResponse] = {
       val result = method.toUpperCase match {
         case "GET" => {
-          _logRequest("GET", _requestHolder(path).withQueryString(queryParameters:_*)).get()
+          _logRequest("GET", _requestHolder(path).withQueryString(queryParameters:_*).withHeaders(headers:_*)).get()
         }
         case "POST" => {
-          _logRequest("POST", _requestHolder(path).withQueryString(queryParameters:_*).withHeaders("Content-Type" -> "application/json; charset=UTF-8")).post(body.getOrElse(play.api.libs.json.Json.obj()))
+          _logRequest("POST", _requestHolder(path).withQueryString(queryParameters:_*).withHeaders("Content-Type" -> "application/json; charset=UTF-8", headers:_*)).post(body.getOrElse(play.api.libs.json.Json.obj()))
         }
         case "PUT" => {
-          _logRequest("PUT", _requestHolder(path).withQueryString(queryParameters:_*).withHeaders("Content-Type" -> "application/json; charset=UTF-8")).put(body.getOrElse(play.api.libs.json.Json.obj()))
+          _logRequest("PUT", _requestHolder(path).withQueryString(queryParameters:_*).withHeaders("Content-Type" -> "application/json; charset=UTF-8", headers:_*)).put(body.getOrElse(play.api.libs.json.Json.obj()))
         }
         case "PATCH" => {
-          _logRequest("PATCH", _requestHolder(path).withQueryString(queryParameters:_*)).patch(body.getOrElse(play.api.libs.json.Json.obj()))
+          _logRequest("PATCH", _requestHolder(path).withQueryString(queryParameters:_*).withHeaders(headers:_*)).patch(body.getOrElse(play.api.libs.json.Json.obj()))
         }
         case "DELETE" => {
-          _logRequest("DELETE", _requestHolder(path).withQueryString(queryParameters:_*)).delete()
+          _logRequest("DELETE", _requestHolder(path).withQueryString(queryParameters:_*).withHeaders(headers:_*)).delete()
         }
          case "HEAD" => {
-          _logRequest("HEAD", _requestHolder(path).withQueryString(queryParameters:_*)).head()
+          _logRequest("HEAD", _requestHolder(path).withQueryString(queryParameters:_*).withHeaders(headers:_*)).head()
         }
          case "OPTIONS" => {
-          _logRequest("OPTIONS", _requestHolder(path).withQueryString(queryParameters:_*)).options()
+          _logRequest("OPTIONS", _requestHolder(path).withQueryString(queryParameters:_*).withHeaders(headers:_*)).options()
         }
         case _ => {
-          _logRequest(method, _requestHolder(path).withQueryString(queryParameters:_*))
+          _logRequest(method, _requestHolder(path).withQueryString(queryParameters:_*).withHeaders(headers:_*))
           sys.error("Unsupported method[%s]".format(method))
         }
       }
       // Close connection if needed
       result.onComplete {
-        case _ => // 
+        case _ => //
           client match {
             case Some(c) =>
               if (autoClose) {
@@ -370,7 +371,7 @@ package com.bryzek.apidoc.reference.api.v0 {
 
     def close: Unit = {
       client match {
-        case Some(c) => 
+        case Some(c) =>
           if (! autoClose)
             c.close
           else

--- a/lib/src/test/resources/generators/reference-spec-play-24.txt
+++ b/lib/src/test/resources/generators/reference-spec-play-24.txt
@@ -329,28 +329,39 @@ package com.bryzek.apidoc.reference.api.v0 {
     )(implicit ec: scala.concurrent.ExecutionContext): scala.concurrent.Future[play.api.libs.ws.WSResponse] = {
       val result = method.toUpperCase match {
         case "GET" => {
-          _logRequest("GET", _requestHolder(path).withQueryString(queryParameters:_*).withHeaders(headers:_*)).get()
+          val request = _requestHolder(path).withQueryString(queryParameters:_*).withHeaders(headers:_*)
+          _logRequest("GET", request).get()
         }
         case "POST" => {
-          _logRequest("POST", _requestHolder(path).withQueryString(queryParameters:_*).withHeaders("Content-Type" -> "application/json; charset=UTF-8", headers:_*)).post(body.getOrElse(play.api.libs.json.Json.obj()))
+          val allHeaders = ("Content-Type" -> "application/json; charset=UTF-8") +: headers
+          val request = _requestHolder(path).withQueryString(queryParameters:_*).withHeaders(allHeaders:_*)
+          _logRequest("POST", request).post(body.getOrElse(play.api.libs.json.Json.obj()))
         }
         case "PUT" => {
-          _logRequest("PUT", _requestHolder(path).withQueryString(queryParameters:_*).withHeaders("Content-Type" -> "application/json; charset=UTF-8", headers:_*)).put(body.getOrElse(play.api.libs.json.Json.obj()))
+          val allHeaders = ("Content-Type" -> "application/json; charset=UTF-8") +: headers
+          val request = _requestHolder(path).withQueryString(queryParameters:_*).withHeaders(allHeaders:_*)
+          val payload = body.getOrElse(play.api.libs.json.Json.obj())
+          _logRequest("PUT", request).put(payload)
         }
         case "PATCH" => {
-          _logRequest("PATCH", _requestHolder(path).withQueryString(queryParameters:_*).withHeaders(headers:_*)).patch(body.getOrElse(play.api.libs.json.Json.obj()))
+          val request = _requestHolder(path).withQueryString(queryParameters:_*).withHeaders(headers:_*)
+          val payload = body.getOrElse(play.api.libs.json.Json.obj())
+          _logRequest("PATCH", request).patch(payload)
         }
         case "DELETE" => {
-          _logRequest("DELETE", _requestHolder(path).withQueryString(queryParameters:_*).withHeaders(headers:_*)).delete()
+          val request = _requestHolder(path).withQueryString(queryParameters:_*).withHeaders(headers:_*)
+          _logRequest("DELETE", request).delete()
         }
          case "HEAD" => {
-          _logRequest("HEAD", _requestHolder(path).withQueryString(queryParameters:_*).withHeaders(headers:_*)).head()
+           val request = _requestHolder(path).withQueryString(queryParameters:_*).withHeaders(headers:_*)
+          _logRequest("HEAD", request).head()
         }
          case "OPTIONS" => {
           _logRequest("OPTIONS", _requestHolder(path).withQueryString(queryParameters:_*).withHeaders(headers:_*)).options()
         }
         case _ => {
-          _logRequest(method, _requestHolder(path).withQueryString(queryParameters:_*).withHeaders(headers:_*))
+          val request = _requestHolder(path).withQueryString(queryParameters:_*).withHeaders(headers:_*)
+          _logRequest(method, request)
           sys.error("Unsupported method[%s]".format(method))
         }
       }

--- a/lib/src/test/resources/generators/reference-with-imports-spec-play-24.txt
+++ b/lib/src/test/resources/generators/reference-with-imports-spec-play-24.txt
@@ -312,38 +312,39 @@ package com.bryzek.apidoc.reference.api.v0 {
       method: String,
       path: String,
       queryParameters: Seq[(String, String)] = Seq.empty,
+      headers: Seq[(String, String)] = Seq.empty,
       body: Option[play.api.libs.json.JsValue] = None
     )(implicit ec: scala.concurrent.ExecutionContext): scala.concurrent.Future[play.api.libs.ws.WSResponse] = {
       val result = method.toUpperCase match {
         case "GET" => {
-          _logRequest("GET", _requestHolder(path).withQueryString(queryParameters:_*)).get()
+          _logRequest("GET", _requestHolder(path).withQueryString(queryParameters:_*).withHeaders(headers:_*)).get()
         }
         case "POST" => {
-          _logRequest("POST", _requestHolder(path).withQueryString(queryParameters:_*).withHeaders("Content-Type" -> "application/json; charset=UTF-8")).post(body.getOrElse(play.api.libs.json.Json.obj()))
+          _logRequest("POST", _requestHolder(path).withQueryString(queryParameters:_*).withHeaders("Content-Type" -> "application/json; charset=UTF-8", headers:_*)).post(body.getOrElse(play.api.libs.json.Json.obj()))
         }
         case "PUT" => {
-          _logRequest("PUT", _requestHolder(path).withQueryString(queryParameters:_*).withHeaders("Content-Type" -> "application/json; charset=UTF-8")).put(body.getOrElse(play.api.libs.json.Json.obj()))
+          _logRequest("PUT", _requestHolder(path).withQueryString(queryParameters:_*).withHeaders("Content-Type" -> "application/json; charset=UTF-8", headers:_*)).put(body.getOrElse(play.api.libs.json.Json.obj()))
         }
         case "PATCH" => {
-          _logRequest("PATCH", _requestHolder(path).withQueryString(queryParameters:_*)).patch(body.getOrElse(play.api.libs.json.Json.obj()))
+          _logRequest("PATCH", _requestHolder(path).withQueryString(queryParameters:_*).withHeaders(headers:_*)).patch(body.getOrElse(play.api.libs.json.Json.obj()))
         }
         case "DELETE" => {
-          _logRequest("DELETE", _requestHolder(path).withQueryString(queryParameters:_*)).delete()
+          _logRequest("DELETE", _requestHolder(path).withQueryString(queryParameters:_*).withHeaders(headers:_*)).delete()
         }
          case "HEAD" => {
-          _logRequest("HEAD", _requestHolder(path).withQueryString(queryParameters:_*)).head()
+          _logRequest("HEAD", _requestHolder(path).withQueryString(queryParameters:_*).withHeaders(headers:_*)).head()
         }
          case "OPTIONS" => {
-          _logRequest("OPTIONS", _requestHolder(path).withQueryString(queryParameters:_*)).options()
+          _logRequest("OPTIONS", _requestHolder(path).withQueryString(queryParameters:_*).withHeaders(headers:_*)).options()
         }
         case _ => {
-          _logRequest(method, _requestHolder(path).withQueryString(queryParameters:_*))
+          _logRequest(method, _requestHolder(path).withQueryString(queryParameters:_*).withHeaders(headers:_*))
           sys.error("Unsupported method[%s]".format(method))
         }
       }
       // Close connection if needed
       result.onComplete {
-        case _ => // 
+        case _ => //
           client match {
             case Some(c) =>
               if (autoClose) {
@@ -358,7 +359,7 @@ package com.bryzek.apidoc.reference.api.v0 {
 
     def close: Unit = {
       client match {
-        case Some(c) => 
+        case Some(c) =>
           if (! autoClose)
             c.close
           else

--- a/lib/src/test/resources/generators/reference-with-imports-spec-play-24.txt
+++ b/lib/src/test/resources/generators/reference-with-imports-spec-play-24.txt
@@ -317,28 +317,39 @@ package com.bryzek.apidoc.reference.api.v0 {
     )(implicit ec: scala.concurrent.ExecutionContext): scala.concurrent.Future[play.api.libs.ws.WSResponse] = {
       val result = method.toUpperCase match {
         case "GET" => {
-          _logRequest("GET", _requestHolder(path).withQueryString(queryParameters:_*).withHeaders(headers:_*)).get()
+          val request = _requestHolder(path).withQueryString(queryParameters:_*).withHeaders(headers:_*)
+          _logRequest("GET", request).get()
         }
         case "POST" => {
-          _logRequest("POST", _requestHolder(path).withQueryString(queryParameters:_*).withHeaders("Content-Type" -> "application/json; charset=UTF-8", headers:_*)).post(body.getOrElse(play.api.libs.json.Json.obj()))
+          val allHeaders = ("Content-Type" -> "application/json; charset=UTF-8") +: headers
+          val request = _requestHolder(path).withQueryString(queryParameters:_*).withHeaders(allHeaders:_*)
+          _logRequest("POST", request).post(body.getOrElse(play.api.libs.json.Json.obj()))
         }
         case "PUT" => {
-          _logRequest("PUT", _requestHolder(path).withQueryString(queryParameters:_*).withHeaders("Content-Type" -> "application/json; charset=UTF-8", headers:_*)).put(body.getOrElse(play.api.libs.json.Json.obj()))
+          val allHeaders = ("Content-Type" -> "application/json; charset=UTF-8") +: headers
+          val request = _requestHolder(path).withQueryString(queryParameters:_*).withHeaders(allHeaders:_*)
+          val payload = body.getOrElse(play.api.libs.json.Json.obj())
+          _logRequest("PUT", request).put(payload)
         }
         case "PATCH" => {
-          _logRequest("PATCH", _requestHolder(path).withQueryString(queryParameters:_*).withHeaders(headers:_*)).patch(body.getOrElse(play.api.libs.json.Json.obj()))
+          val request = _requestHolder(path).withQueryString(queryParameters:_*).withHeaders(headers:_*)
+          val payload = body.getOrElse(play.api.libs.json.Json.obj())
+          _logRequest("PATCH", request).patch(payload)
         }
         case "DELETE" => {
-          _logRequest("DELETE", _requestHolder(path).withQueryString(queryParameters:_*).withHeaders(headers:_*)).delete()
+          val request = _requestHolder(path).withQueryString(queryParameters:_*).withHeaders(headers:_*)
+          _logRequest("DELETE", request).delete()
         }
          case "HEAD" => {
-          _logRequest("HEAD", _requestHolder(path).withQueryString(queryParameters:_*).withHeaders(headers:_*)).head()
+           val request = _requestHolder(path).withQueryString(queryParameters:_*).withHeaders(headers:_*)
+          _logRequest("HEAD", request).head()
         }
          case "OPTIONS" => {
           _logRequest("OPTIONS", _requestHolder(path).withQueryString(queryParameters:_*).withHeaders(headers:_*)).options()
         }
         case _ => {
-          _logRequest(method, _requestHolder(path).withQueryString(queryParameters:_*).withHeaders(headers:_*))
+          val request = _requestHolder(path).withQueryString(queryParameters:_*).withHeaders(headers:_*)
+          _logRequest(method, request)
           sys.error("Unsupported method[%s]".format(method))
         }
       }

--- a/scala-generator/src/main/scala/models/Play2ClientGenerator.scala
+++ b/scala-generator/src/main/scala/models/Play2ClientGenerator.scala
@@ -155,28 +155,39 @@ ${methodGenerator.objects().indent(4)}
     )(implicit ec: scala.concurrent.ExecutionContext): scala.concurrent.Future[${version.config.responseClass}] = {
       val result = method.toUpperCase match {
         case "GET" => {
-          _logRequest("GET", _requestHolder(path).withQueryString(queryParameters:_*).withHeaders(headers:_*)).get()
+          val request = _requestHolder(path).withQueryString(queryParameters:_*).withHeaders(headers:_*)
+          _logRequest("GET", request).get()
         }
         case "POST" => {
-          _logRequest("POST", _requestHolder(path).withQueryString(queryParameters:_*).withHeaders("Content-Type" -> "application/json; charset=UTF-8", headers:_*)).post(body.getOrElse(play.api.libs.json.Json.obj()))
+          val allHeaders = ("Content-Type" -> "application/json; charset=UTF-8") +: headers
+          val request = _requestHolder(path).withQueryString(queryParameters:_*).withHeaders(allHeaders:_*)
+          _logRequest("POST", request).post(body.getOrElse(play.api.libs.json.Json.obj()))
         }
         case "PUT" => {
-          _logRequest("PUT", _requestHolder(path).withQueryString(queryParameters:_*).withHeaders("Content-Type" -> "application/json; charset=UTF-8", headers:_*)).put(body.getOrElse(play.api.libs.json.Json.obj()))
+          val allHeaders = ("Content-Type" -> "application/json; charset=UTF-8") +: headers
+          val request = _requestHolder(path).withQueryString(queryParameters:_*).withHeaders(allHeaders:_*)
+          val payload = body.getOrElse(play.api.libs.json.Json.obj())
+          _logRequest("PUT", request).put(payload)
         }
         case "PATCH" => {
-          $patchMethod
+          val request = _requestHolder(path).withQueryString(queryParameters:_*).withHeaders(headers:_*)
+          val payload = body.getOrElse(play.api.libs.json.Json.obj())
+          _logRequest("PATCH", request).patch(payload)
         }
         case "DELETE" => {
-          _logRequest("DELETE", _requestHolder(path).withQueryString(queryParameters:_*).withHeaders(headers:_*)).delete()
+          val request = _requestHolder(path).withQueryString(queryParameters:_*).withHeaders(headers:_*)
+          _logRequest("DELETE", request).delete()
         }
          case "HEAD" => {
-          _logRequest("HEAD", _requestHolder(path).withQueryString(queryParameters:_*).withHeaders(headers:_*)).head()
+           val request = _requestHolder(path).withQueryString(queryParameters:_*).withHeaders(headers:_*)
+          _logRequest("HEAD", request).head()
         }
          case "OPTIONS" => {
           _logRequest("OPTIONS", _requestHolder(path).withQueryString(queryParameters:_*).withHeaders(headers:_*)).options()
         }
         case _ => {
-          _logRequest(method, _requestHolder(path).withQueryString(queryParameters:_*).withHeaders(headers:_*))
+          val request = _requestHolder(path).withQueryString(queryParameters:_*).withHeaders(headers:_*)
+          _logRequest(method, request)
           sys.error("Unsupported method[%s]".format(method))
         }
       }

--- a/scala-generator/src/test/scala/models/Play2ClientGeneratorSpec.scala
+++ b/scala-generator/src/test/scala/models/Play2ClientGeneratorSpec.scala
@@ -71,6 +71,12 @@ class Play2ClientGeneratorSpec extends FunSpec with ShouldMatchers {
     models.TestHelper.assertEqualsFile("/generators/play2-client-generator-spec-errors-package-no-models.txt", contents)
   }
 
+  it("generates methods with separate parameter lists for formal parameters and headers") {
+    lazy val service = models.TestHelper.parseFile("/examples/play2-client-generator-spec-has-headers.json")
+    val contents = ScalaClientMethodGenerator(clientMethodConfig, ScalaService(service)).objects()
+    models.TestHelper.assertEqualsFile("/generators/play2-client-generator-spec-errors-package-no-models-with-headers.txt", contents)
+  }
+
 /*
   it("model, enum and union use case - https://github.com/mbryzek/apidoc/issues/384") {
     val json = models.TestHelper.readFile("lib/src/test/resources/generators/play-2-union-model-enum-service.json")


### PR DESCRIPTION
Update the scala play clients to take any headers defined in the spec as an additional parameter group. This mostly involves changing the method generation logic to work with a set of header specifications.

This change requires all generated clients to accept a set of headers, which is why other test files required updating.
